### PR TITLE
Remove description-file field from setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,5 +2,4 @@
 universal=1
 
 [metadata]
-description-file = README.md 
 license_file = LICENSE


### PR DESCRIPTION
This has no effect when using setuptools and triggers
a deprecation warning due to the use of - in the name.
The readme is already included via long_description in setup.py